### PR TITLE
Fix vercel build errors: node types and metamask sdk

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,12 @@ const nextConfig = {
     domains: ['assets.coingecko.com', 'raw.githubusercontent.com'],
   },
   webpack: (config) => {
-    config.resolve.fallback = { fs: false, net: false, tls: false };
+    config.resolve.fallback = { 
+      fs: false, 
+      net: false, 
+      tls: false,
+      '@react-native-async-storage/async-storage': false
+    };
     config.externals.push('pino-pretty', 'lokijs', 'encoding');
     return config;
   },


### PR DESCRIPTION
Fix Vercel build failures by installing `@types/node` and adding a webpack fallback for MetaMask SDK's React Native async storage dependency.

The Vercel build was failing because `@types/node` was missing, and the `@metamask/sdk` (a transitive dependency) was attempting to import `@react-native-async-storage/async-storage`, which is not available in Next.js. This PR resolves the latter by configuring a webpack fallback in `next.config.js`.

---
<a href="https://cursor.com/background-agent?bcId=bc-32a88c5d-2849-4c9e-879b-76c9965c14bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-32a88c5d-2849-4c9e-879b-76c9965c14bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

