### PR TITLE
Integrate as Farcaster miniapp

### DIFF
--- a/public/.well-known/farcaster.json
+++ b/public/.well-known/farcaster.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "name": "Trickle Base Faucet",
   "description": "Get $0.025 worth of ETH for gas fees on Base mainnet. A Farcaster miniapp for seamless crypto transactions.",
-  "icon": "/th.png",
-  "splash": "/ti.png",
+  "icon": "/ti.png",
+  "splash": "/ts.png",
   "url": "https://trickle-faucet.vercel.app",
   "category": "utility",
   "tags": ["Base", "faucet", "ETH", "gas fees", "crypto", "web3"],
@@ -25,11 +25,11 @@
   "screenshots": [
     {
       "url": "/tp.png",
-      "alt": "Trickle Faucet Interface"
+      "alt": "Trickle Faucet Preview"
     },
     {
-      "url": "/ts.png", 
-      "alt": "Trickle Faucet Stats"
+      "url": "/th.png", 
+      "alt": "Trickle Faucet Hero"
     }
   ],
   "miniapp": {

--- a/public/browserconfig.xml
+++ b/public/browserconfig.xml
@@ -2,7 +2,7 @@
 <browserconfig>
     <msapplication>
         <tile>
-            <square150x150logo src="/th.png"/>
+            <square150x150logo src="/ti.png"/>
             <TileColor>#0052FF</TileColor>
         </tile>
     </msapplication>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -12,7 +12,7 @@
   "categories": ["finance", "utilities"],
   "icons": [
     {
-      "src": "/th.png",
+      "src": "/ti.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any maskable"
@@ -24,13 +24,13 @@
       "purpose": "any maskable"
     },
     {
-      "src": "/tp.png",
+      "src": "/ti.png",
       "sizes": "256x256", 
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "/ts.png",
+      "src": "/ti.png",
       "sizes": "256x256",
       "type": "image/png", 
       "purpose": "any"
@@ -42,14 +42,14 @@
       "sizes": "1280x720",
       "type": "image/png",
       "form_factor": "wide",
-      "label": "Trickle Faucet Interface"
+      "label": "Trickle Faucet Preview"
     },
     {
-      "src": "/ts.png",
+      "src": "/th.png",
       "sizes": "1280x720", 
       "type": "image/png",
       "form_factor": "wide",
-      "label": "Trickle Faucet Stats"
+      "label": "Trickle Faucet Hero"
     }
   ],
   "shortcuts": [
@@ -60,7 +60,7 @@
       "url": "/",
       "icons": [
         {
-          "src": "/th.png",
+          "src": "/ti.png",
           "sizes": "96x96"
         }
       ]

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,16 +22,16 @@ export const metadata: Metadata = {
     siteName: 'Trickle Base Faucet',
     images: [
       {
-        url: '/th.png',
+        url: '/tp.png',
         width: 1200,
         height: 630,
         alt: 'Trickle Base Faucet - Get ETH for gas fees',
       },
       {
-        url: '/ti.png',
+        url: '/th.png',
         width: 800,
         height: 600,
-        alt: 'Trickle Base Faucet Interface',
+        alt: 'Trickle Base Faucet Hero',
       },
     ],
   },
@@ -39,11 +39,11 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: 'Trickle - Base Faucet',
     description: 'Get $0.025 worth of ETH for gas fees on Base mainnet. A Farcaster miniapp for seamless crypto transactions.',
-    images: ['/th.png'],
+    images: ['/tp.png'],
   },
   other: {
     'farcaster:frame': 'vNext',
-    'farcaster:frame:image': '/th.png',
+    'farcaster:frame:image': '/tp.png',
     'farcaster:frame:button:1': 'Get ETH',
     'farcaster:frame:button:1:action': 'link',
     'farcaster:frame:button:1:target': 'https://trickle-faucet.vercel.app',
@@ -68,7 +68,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <link rel="icon" href="/th.png" />
+        <link rel="icon" href="/ti.png" />
         <link rel="apple-touch-icon" href="/ti.png" />
         <link rel="manifest" href="/manifest.json" />
         <link rel="canonical" href="https://trickle-faucet.vercel.app" />


### PR DESCRIPTION
Convert the application into a Farcaster miniapp by adding Farcaster, Open Graph, and PWA metadata and configuration files.

---
<a href="https://cursor.com/background-agent?bcId=bc-1aa62312-eb87-4e9c-b753-6f112630b663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1aa62312-eb87-4e9c-b753-6f112630b663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

